### PR TITLE
#37 access token 재발급 error resolved

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -50,6 +50,22 @@ axiosInstance.interceptors.response.use(
           },
         });
       }
+    }
+    if (error.response.status === 500 && !originalRequest._retry) {
+      console.log('Handling 500 error - attempting to refresh token');
+      originalRequest._retry = true;
+      delete originalRequest.headers.Authorization;
+      const newAccessToken = await getNewAccessToken(); // 토큰 재발급 받기
+      if (newAccessToken) {
+        localStorage.setItem('accessToken', newAccessToken);
+        return axiosInstance({
+          ...originalRequest,
+          headers: {
+            ...originalRequest.headers,
+            Authorization: `Bearer ${newAccessToken}`,
+          },
+        });
+      }
     } else if (error.response.status === 400) {
       signout();
     }

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -8,8 +8,8 @@ export const getNewAccessToken = async () => {
       {},
       { withCredentials: true },
     );
-    if (response.status === 200) {
-      const newAccessToken = response.data.accessToken;
+    if (response.status === 200 && response.headers.authorization) {
+      const newAccessToken = response.headers.authorization.split(' ')[1];
       localStorage.setItem('accessToken', newAccessToken);
       return newAccessToken;
     }


### PR DESCRIPTION
- 서버에서 500 에러 반환 시 에러 처리 로직 추가
- 토큰을 저장하는 로직을 response.data.accessToken에서 response.headers.authorization로 변경